### PR TITLE
Change package.json URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Rod Vagg <rod@vagg.org> (https://github.com/rvagg)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/rvagg/workshopper.git"
+    "url": "https://github.com/workshopper/workshopper-adventure.git"
   },
   "license": "MIT",
   "dependencies": {
@@ -25,9 +25,9 @@
     "xtend": "~3.0.0"
   },
   "bugs": {
-    "url": "https://github.com/rvagg/workshopper/issues"
+    "url": "https://github.com/workshopper/workshopper-adventure/issues"
   },
-  "homepage": "https://github.com/rvagg/workshopper",
+  "homepage": "https://github.com/workshopper/workshopper-adventure",
   "directories": {
     "example": "examples"
   },


### PR DESCRIPTION
I would like to contribute workshopper-adventure. But I could not find this repository.
Because [npm url](https://www.npmjs.com/package/workshopper-adventure)  does not show correct url...