### PR TITLE
Passed through optional fn parameter in add

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ WA.prototype.execute = function (args) {
 WA.prototype.add = function (nameOrObject, fnOrObject, fn) {
   var meta
   try {
-    meta = require('./lib/createExerciseMeta')(this.options.exerciseDir, nameOrObject, fnOrObject)
+    meta = require('./lib/createExerciseMeta')(this.options.exerciseDir, nameOrObject, fnOrObject, fn)
   } catch (e) {
     console.log(e)
     return new Error(this.__('error.exercise.' + e.id, e))


### PR DESCRIPTION
It looks like, based on the parameters of `lib/createExerciseMeta`, the `fn` parameter should have been passed through on `WA.prototype.add`.  