### PR TITLE
Fixes invalid JSON in German translation

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -23,7 +23,7 @@
     "pl": "Polnisch (Polski)",
     "nb-no": "Norwegisch (Norsk)",
     "it": "Italienisch (Italiano)",
-    "sr": "Serbisch (српски)",
+    "sr": "Serbisch (српски)"
   },
   "error": {
     "exercise": {


### PR DESCRIPTION
There's a trailing comma in `i18n/de.json` resulting in garbled German translation of workshops.

Found while reviewing https://github.com/workshopper/learn-sass/pull/61.