### PR TITLE
[fix #145] Provide the official solution code if applicable

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,7 +222,7 @@ WA.prototype.exercisePass = function (mode, exercise, stream, cb) {
         if ((files && files.length > 0) || exercise.solution) {
           stream.append('{solution.notes.compare}')
           if (exercise.solutionPath) {
-            stream.append({ files : [exercise.solutionPath] })
+            stream.append({ files: [exercise.solutionPath] })
           }
         }
 

--- a/index.js
+++ b/index.js
@@ -221,6 +221,9 @@ WA.prototype.exercisePass = function (mode, exercise, stream, cb) {
       if (hideSolutions !== true) {
         if ((files && files.length > 0) || exercise.solution) {
           stream.append('{solution.notes.compare}')
+          if (exercise.solutionPath) {
+            stream.append({ files : [exercise.solutionPath] })
+          }
         }
 
         files && files.length > 0


### PR DESCRIPTION
Some workshoppers (for example `javascripting`) which are dependent of `workshopper-adventure` will have the official solution file into a `solutionPath` property, so I just appended this to the stream if applicable.