### PR TITLE
Fix verify always failing

### DIFF
--- a/index.js
+++ b/index.js
@@ -447,7 +447,7 @@ WA.prototype.executeExercise = function (exercise, mode, method, args, stream, c
           err = null
         }
 
-        pass = mode === 'run' || pass)
+        pass = mode === 'run' || pass
         err
           ? cleanup(err, null, message)
           : cleanup(null, pass, message)

--- a/index.js
+++ b/index.js
@@ -447,7 +447,7 @@ WA.prototype.executeExercise = function (exercise, mode, method, args, stream, c
           err = null
         }
 
-        pass = (mode === 'run' || (pass && !exercise.fail))
+        pass = mode === 'run' || pass)
         err
           ? cleanup(err, null, message)
           : cleanup(null, pass, message)


### PR DESCRIPTION
I tried to use workshopper-adventure instead of adventure and was running into an issue.

The verify was always failing, because there is a weird check that verify needs to pass, but also `exercise.fail` is not allowed to be truthy.

However `exercise.fail` is the is the text that's shown when it fails. So it's always truthy...