### PR TITLE
feat(util/idFromName): allow customize character for white space

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,11 @@
   },
   "devDependencies": {
     "standard": "^14.2.0",
-    "standard-version": "^7.0.0"
+    "standard-version": "^7.0.0",
+    "tape": "^4.11.0"
   },
   "scripts": {
-    "test": "./node_modules/.bin/standard",
+    "test": "standard && tape test/**/*",
     "release": "./node_modules/.bin/standard-version"
   }
 }

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,0 +1,14 @@
+const util = require('../util')
+const test = require('tape')
+
+// idFromName
+const name = 'TEST CHALLENGE'
+test('remove white spaces with underscore', (t) => {
+  t.plan(1)
+  t.equal(util.idFromName(name), 'test_challenge')
+})
+
+test('allow customize character to replace white space', (t) => {
+  t.plan(1)
+  t.equal(util.idFromName(name, '-'), 'test-challenge')
+})

--- a/util.js
+++ b/util.js
@@ -1,15 +1,16 @@
 const path = require('path')
 const fs = require('fs')
 
-function idFromName (id) {
+function idFromName (id, spaceChar = '_') {
   if (id === null || id === undefined) {
     id = ''
   }
+  const regex = new RegExp(`[^\\w${spaceChar}]`, 'gi')
 
   return id.toString().toLowerCase()
     .replace(/^\s+|\s+$/g, '')
-    .replace(/\s/g, '_')
-    .replace(/[^\w]/gi, '')
+    .replace(/\s/g, spaceChar)
+    .replace(regex, '')
 }
 
 function dirFromName (exerciseDir, name) {


### PR DESCRIPTION
Some workshoppers use a character different to `_` for folder names. So in order to load the folder correctly for verify solutions, we need to customize the character used for replace white spaces in exercise names.