### PR TITLE
update: latest version of simple-terminal-menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "i18n-core": "^3.0.0",
     "latest-version": "^5.1.0",
     "msee": "^0.3.5",
-    "simple-terminal-menu": "^1.1.3",
+    "simple-terminal-menu": "^2.0.0",
     "split": "^1.0.0",
     "string-to-stream": "^3.0.1",
     "strip-ansi": "^6.0.0",


### PR DESCRIPTION
This PR updates simple-terminal-menu. The new simple-terminal has a few breaking changes that don't apply to learnyounode or javascripting but they could be affecting other workshoppers like `levelmeup` as the colors are changed now. Previously `simple-terminal-menu` would use ansi16 colors which are keyworded and can be changed by terminal implementations. Now it uses `ansi256` colors which are strictly defined - and consequently should work in all terminals equally in a way how everyone can see the output.

_Note: I havn't had a chance to test it on windows yet, help welcome!_